### PR TITLE
Avoid the manually change frontend deployment after helm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,19 +16,23 @@ The chart is located in the ```bookstore-chart``` folder.
 
 ```oc apply -f pipelines-operator.yaml```
 
-3. Test the chart with a dry run (just to be sure that everyrhing is formally fine):
+3. Customize the chart values before running.
+   Update the `ocpHostDomain` with your current OCP domain URL before running the chart:
+
+   ```
+   sed -i 's/^ocpHostDomain: "<CHANGE_TO_YOUR_HOST>"/ocpHostDomain: ocp4.demo.example.com/g' bookstore-chart/values.yaml
+   ```
+
+   Alternatively, it is possible to dinamically override a value from command line
+   with the `--set key=value` option without touching the `bookstore-chart/values.yaml` file.
+
+4. Test the chart with a dry run (just to be sure that everyrhing is formally fine):
 
 ```helm install --generate-name --dry-run bookstore-chart```
 
-4. Go to the project source root and install the chart: 
+5. Go to the project source root and install the chart: 
 
 ```helm install --generate-name bookstore-chart```
-
-5. At the end of installation in  the *"Post install Front End setup for demo"* the chart will **output a command** to update the frontend deployment environment variables with urls of the two ReST services: **copy the command and run it** (you need to be logged in your openshift). The command is something like:
-
-```
-oc patch  deployment/bookstore-chart-1605264575-fe -p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"env\":[{\"name\":\"BOOKSAPIURL\",\"value\":\"http://$(oc get route bookstore-books-api -o jsonpath='{.status.ingress[0].host}' --namespace bookstore-demo)\"},{\"name\":\"BOOKSTOCKAPIURL\",\"value\":\"http://$(oc get route bookstore-stock-api  -o jsonpath='{.status.ingress[0].host}' --namespace bookstore-demo)\"}],\"name\":\"bookstore-chart-fe\"}]}}}}" --namespace bookstore-demo
-```
 
 6. Start the Tekton pipelines
 

--- a/bookstore-chart/templates/NOTES.txt
+++ b/bookstore-chart/templates/NOTES.txt
@@ -1,6 +1,6 @@
 Your {{ include "bookstore-chart.name" . }} is installed/updated
 
-1. You may test the services with the following URLs after you build from source
+You may test the services with the following URLs after you build from source
 
   Books ReST service (Java)    
 
@@ -22,9 +22,4 @@ Your {{ include "bookstore-chart.name" . }} is installed/updated
 
       echo "http://"$(oc get route bookstore-stock-api  -o jsonpath='{.status.ingress[0].host}' --namespace {{ .Release.Namespace }})"/booksavailability/1"      
 
-2. Post install Front End setup for demo
-  
-  After all the items are installed you need to update the front-end containers env variables with the URLs of the ReST services:
-
-  oc patch  deployment/{{ include "bookstore-chart.fullname" . }}-fe -p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"env\":[{\"name\":\"BOOKSAPIURL\",\"value\":\"http://$(oc get route bookstore-books-api -o jsonpath='{.status.ingress[0].host}' --namespace {{ .Release.Namespace }})\"},{\"name\":\"BOOKSTOCKAPIURL\",\"value\":\"http://$(oc get route bookstore-stock-api  -o jsonpath='{.status.ingress[0].host}' --namespace {{ .Release.Namespace }})\"}],\"name\":\"bookstore-chart-fe\"}]}}}}" --namespace {{ .Release.Namespace }}
 

--- a/bookstore-chart/templates/fe/bookstore-fe-deployment.yaml
+++ b/bookstore-chart/templates/fe/bookstore-fe-deployment.yaml
@@ -35,9 +35,9 @@ spec:
           image: "{{ .Values.image.repository }}/{{ .Release.Namespace }}/bookstore-fe:{{ .Values.image.tag | default .Chart.AppVersion }}"
           env:
             - name: BOOKSAPIURL
-              value: "http://bookstore-books-api-{{ .Release.Namespace }}{{ .Values.ocphostdomain }}"
+              value: "http://bookstore-books-api-{{ .Release.Namespace }}.{{ .Values.ocpHostDomain }}"
             - name: BOOKSTOCKAPIURL
-              value: "http://bookstore-stock-api-{{ .Release.Namespace }}{{ .Values.ocphostdomain }}"
+              value: "http://bookstore-stock-api-{{ .Release.Namespace }}.{{ .Values.ocpHostDomain }}"
             - name: PORT
               value: "8080"   
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/bookstore-chart/values.yaml
+++ b/bookstore-chart/values.yaml
@@ -69,4 +69,6 @@ tolerations: []
 
 affinity: {}
 
-ocphostdomain: "<CHANGE_TO_YOUR_HOST>"
+# Update the value of ocpHostDomain before running the chart
+ocpHostDomain: "<CHANGE_TO_YOUR_HOST>"
+


### PR DESCRIPTION
Accomplished by fxing the urls construction logic in the frontend deployment template env section.